### PR TITLE
Make helpers.`->` use edge.`->`

### DIFF
--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -13,7 +13,7 @@ proc p*( x, y: float ): tuple[x, y: float] =
 
 proc `->`*( a, b: tuple[x, y: float] ): Edge[tuple[x, y: float]] =
     ## Creates an edge from two tuples
-    result = (a: a, b: b)
+    result = edge.`->`(a, b)
 
 proc `==`*[T]( actual: seq[T], expected: openArray[T] ): bool =
     ## Allows you to compare a sequence to an array


### PR DESCRIPTION
The original `->` in `edge` sorts the parameters before forming the edge, but helpers.`->` doesn't do this.

helpers.`->` also has a more precise signature (on `tuple[x, y: float]` rather than the `Point` concept), which means generic procs can prefer it if `->` is considered to be overloaded.

This has not been an issue in this package because the generic procs that use `->` only have access to 1 overload of it and so Nim considers them not overloaded. However this behavior is not reliable: https://github.com/nim-lang/Nim/issues/11184, and so attempts to fix this cause issues in this library's tests.

Alternatively the tests can use another operator to form unsorted edges, or the signature of helpers.`->` can be made equally as precise as the one in `edge` (i.e. defined on `Point`).